### PR TITLE
Add mitigations for BREACH.

### DIFF
--- a/htb/htb.go
+++ b/htb/htb.go
@@ -1,0 +1,38 @@
+// Package htb implements mitigations for the BREACH attack.
+// Heal-the-BREACH involves inserting a random filename into the header section of gzip,
+// modifying the overall length of a response, and increasing the time taken to perform BREACH substantially.
+//
+// Note: this does not remove the possibility, only prolongs it.
+package htb
+
+import (
+	"crypto/rand"
+	"math/big"
+)
+
+const (
+	paddingSize = 32
+	characters  = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+	length      = int64(len(characters))
+)
+
+var max = big.NewInt(length)
+
+// RandomString produces a cryptographically secure random string, or panics.
+// It will be 32 bytes long, and alphanumeric.
+//
+// This should be pretty fast, and suitable for concurrent use.
+func RandomString() string {
+	buf := make([]byte, paddingSize)
+
+	for i := range buf {
+		n, err := rand.Int(rand.Reader, max)
+		if err != nil {
+			panic(err)
+		}
+
+		buf[i] = characters[n.Int64()]
+	}
+
+	return string(buf)
+}

--- a/htb/htb_test.go
+++ b/htb/htb_test.go
@@ -1,0 +1,22 @@
+package htb
+
+import (
+	"testing"
+)
+
+func TestRandomString(t *testing.T) {
+	for n := 0; n < 100; n++ {
+		str := RandomString()
+
+		switch {
+		case len(str) != paddingSize:
+			t.Fatalf("Expected all results from RandomString to have length %d, got %d", paddingSize, len(str))
+		}
+	}
+}
+
+func BenchmarkRandomString(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		RandomString()
+	}
+}

--- a/rpc.go
+++ b/rpc.go
@@ -11,6 +11,8 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+
+	"github.com/go-qbit/rpc/htb"
 )
 
 var boundaryRe = regexp.MustCompile(`;.*boundary=(.*)`)
@@ -154,6 +156,8 @@ func (r *Rpc) ServeHTTP(w http.ResponseWriter, request *http.Request) {
 		w.Header().Set("Content-Encoding", "gzip")
 
 		gzW := gzip.NewWriter(writer)
+		gzW.Header.Name = htb.RandomString() // See https://ieeexplore.ieee.org/document/9754554
+
 		defer gzW.Close()
 
 		writer = gzW


### PR DESCRIPTION
This pull request fixes a security issue in this library, namely [BREACH](https://ieeexplore.ieee.org/document/9754554).

The fix is to add a randomly generated 'filename' to the header section of the gzip payload.

This only adds around 12000 ns, or 0.012 ms per request.